### PR TITLE
로그인한 유저의 Header 변경 및 Modal 기능 추가

### DIFF
--- a/src/assets/DownIcon.tsx
+++ b/src/assets/DownIcon.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const DownIcon = () => {
+  return (
+    <StyledDownIcon className='DownIcon'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='16'
+        height='16'
+        fill='currentColor'
+        viewBox='0 0 16 16'
+      >
+        <path
+          // fill-rule='evenodd'
+          d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'
+        />
+      </svg>
+    </StyledDownIcon>
+  );
+};
+
+const StyledDownIcon = styled.span`
+  position: relative;
+  svg {
+    color: grey;
+    width: 17px;
+    height: 17px;
+    cursor: pointer;
+  }
+`;
+export default DownIcon;

--- a/src/assets/PersonIcon.tsx
+++ b/src/assets/PersonIcon.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+const PersonIcon = () => {
+  return (
+    <StyledPersonIcon className='PersonIcon'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='16'
+        height='16'
+        fill='currentColor'
+        viewBox='0 0 16 16'
+      >
+        <path d='M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z' />
+        <path
+          // fill-rule='evenodd'
+          d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z'
+        />
+      </svg>
+    </StyledPersonIcon>
+  );
+};
+
+const StyledPersonIcon = styled.span`
+  position: relative;
+  svg {
+    color: #00c7af;
+    width: 22px;
+    height: 22px;
+    cursor: pointer;
+  }
+`;
+export default PersonIcon;

--- a/src/assets/UpIcon.tsx
+++ b/src/assets/UpIcon.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const UpIcon = () => {
+  return (
+    <StyledUpIcon className='UpIcon'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='16'
+        height='16'
+        fill='currentColor'
+        viewBox='0 0 16 16'
+      >
+        <path
+          // fill-rule='evenodd'
+          d='M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z'
+        />
+      </svg>
+    </StyledUpIcon>
+  );
+};
+
+const StyledUpIcon = styled.span`
+  position: relative;
+  svg {
+    color: grey;
+    width: 17px;
+    height: 17px;
+    cursor: pointer;
+  }
+`;
+export default UpIcon;

--- a/src/common/Header/HeaderLogin.tsx
+++ b/src/common/Header/HeaderLogin.tsx
@@ -1,0 +1,27 @@
+import styles from './style.module.scss';
+import UpIcon from '../../assets/UpIcon';
+import DownIcon from '../../assets/DownIcon';
+import { useState } from 'react';
+import HeaderToggle from './HeaderToggle';
+import PersonIcon from '../../assets/PersonIcon';
+
+const HeaderLogin = () => {
+  const userNickname = localStorage.getItem('nickname');
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <header className={styles.HeaderLogin}>
+      <button type='button' className={styles.HeaderLogin__box} onClick={() => toggle()}>
+        <PersonIcon />
+        <div className={styles.HeaderLogin__box__username}>{userNickname}</div>
+        {isOpen ? <UpIcon /> : <DownIcon />}
+      </button>
+      {isOpen && <HeaderToggle />}
+    </header>
+  );
+};
+
+export default HeaderLogin;

--- a/src/common/Header/HeaderLogout.tsx
+++ b/src/common/Header/HeaderLogout.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '../../components/styled-components/Button';
+import styles from './style.module.scss';
+
+const HeaderLogout = () => {
+  const navigate = useNavigate();
+  return (
+    <header className={styles.HeaderLogout}>
+      <Button
+        text='로그인'
+        onClick={() => navigate('/login')}
+        width='88px'
+        height='40px'
+        color='#000'
+        background='#fff'
+      />
+      <Button text='회원가입' onClick={() => navigate('/signup')} width='94px' height='40px' />
+    </header>
+  );
+};
+
+export default HeaderLogout;

--- a/src/common/Header/HeaderToggle.tsx
+++ b/src/common/Header/HeaderToggle.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-duplicates */
+import { useNavigate } from 'react-router-dom';
+// import Button from '../../components/styled-components/Button';
+import styles from './style.module.scss';
+import { Link } from 'react-router-dom';
+
+const HeaderToggle = () => {
+  const navigate = useNavigate();
+  const userNickname = localStorage.getItem('nickname');
+  const logout = () => {
+    localStorage.clear();
+    // eslint-disable-next-line no-alert
+    alert('로그아웃 되었습니다');
+    navigate('/');
+    window.location.reload();
+  };
+  return (
+    <div className={styles.HeaderToggle}>
+      <div className={styles.HeaderToggle__box}>
+        <div className={styles.HeaderToggle__box__username}>{userNickname} 님</div>
+        <div className={styles.HeaderToggle__box__mypage}>
+          <Link to='/users/:userId' style={{ textDecoration: 'none' }}>
+            마이페이지
+          </Link>
+        </div>
+      </div>
+      <div className={styles.HeaderToggle__logout} onClick={logout} role='presentation'>
+        로그아웃
+      </div>
+    </div>
+  );
+};
+
+export default HeaderToggle;

--- a/src/common/Header/index.tsx
+++ b/src/common/Header/index.tsx
@@ -1,12 +1,14 @@
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
-import Button from '../../components/styled-components/Button';
+import { useEffect, useState } from 'react';
+// import Button from '../../components/styled-components/Button';
 import styles from './style.module.scss';
 import ModeToggle from '../../components/styled-components/ModeToggle';
 import DesktopLogo from '../../assets/TextLogo';
 import ListIcon from '../../assets/ListIcon';
 import SidebarLogin from '../../components/Sidebar/SidebarLogin';
 import SidebarLogout from '../../components/Sidebar/SidebarLogout';
+import HeaderLogout from './HeaderLogout';
+import HeaderLogin from './HeaderLogin';
 
 const Header = () => {
   const navigate = useNavigate();
@@ -15,12 +17,15 @@ const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleMenu = () => {
     setIsOpen(!isOpen);
+  };
+
+  useEffect(() => {
     if (localLength) {
       setIsLoginUser(true);
     } else {
       setIsLoginUser(false);
     }
-  };
+  }, [localLength]);
 
   return (
     <header className={styles.Header}>
@@ -35,15 +40,8 @@ const Header = () => {
         </button>
         <div className={styles.Header__nav__right}>
           <ModeToggle />
-          <Button
-            text='로그인'
-            onClick={() => navigate('/login')}
-            width='88px'
-            height='40px'
-            color='#000'
-            background='#fff'
-          />
-          <Button text='회원가입' onClick={() => navigate('/signup')} width='94px' height='40px' />
+          {isLoginUser ? <HeaderLogin /> : ''}
+          {!isLoginUser ? <HeaderLogout /> : ''}
         </div>
       </section>
     </header>

--- a/src/common/Header/style.module.scss
+++ b/src/common/Header/style.module.scss
@@ -8,7 +8,6 @@
   justify-content: center;
   top: 0;
   background-color: var(--color-background);
-
   margin: auto;
   height: 72px;
   border-bottom: 1px solid #ececec;
@@ -23,6 +22,60 @@
     &__right {
       display: flex;
     }
+  }
+}
+
+.HeaderLogin {
+  display: flex;
+  margin-left: 20px;
+  &__box {
+    display: flex;
+    align-items: center;
+    &__username {
+      font-size: 0.8rem;
+      color: rgb(69, 69, 69);
+      height: 20px;
+      margin: 4px 15px 0 8px;
+    }
+  }
+}
+
+.HeaderToggle {
+  position: absolute;
+  top: 60px;
+  border: 1px solid #e6e6e6;
+  background-color: white;
+  cursor: pointer;
+
+  &__box {
+    color: rgb(69, 69, 69);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    width: 150px;
+    height: 60px;
+    &__username {
+      font-size: 1rem;
+      font-weight: bold;
+    }
+    &__mypage {
+      font-size: 0.8rem;
+      margin-top: 30px;
+      a {
+        color: rgb(69, 69, 69);
+      }
+    }
+  }
+  &__logout {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: rgb(69, 69, 69);
+    font-weight: bold;
+    background-color: #f2f2f2;
+    width: 100%;
+    height: 35px;
+    font-size: 0.85rem;
   }
 }
 

--- a/src/components/Sidebar/SidebarLogin.tsx
+++ b/src/components/Sidebar/SidebarLogin.tsx
@@ -7,6 +7,9 @@ const SidebarLogin = () => {
 
   const logout = () => {
     localStorage.clear();
+    // eslint-disable-next-line no-alert
+    alert('로그아웃 되었습니다');
+    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
## 작업사항 :memo:
- 로그인한 유저의 Header 변경
- 헤더 Modal 기능 추가 
- 로그아웃 기능 추가 (reload, alert 추가) 

1️⃣ 로그인 했을 때, 헤더 모양 변경 및 모달 오픈 가능!
![로그인했을 때, 헤더 모달](https://user-images.githubusercontent.com/124070996/234334117-129e975b-489e-496a-bf32-0ecb4bb60b79.gif)

2️⃣ 로그인 했을 때, 헤더 모달 내 '마이페이지 & 로그아웃 기능' 클릭 가능!
![로그인했을 때, 헤더 모달_링크 작동](https://user-images.githubusercontent.com/124070996/234334422-8c13826e-86ef-451e-8662-88106752d06e.gif)


## To-do 🤩
- 로그아웃 시, API 호출 추가 

cf) 4월 26일 수요일, 새로운 기능 '게시판' API 명세서 나오는 대로, '게시판' 작업 시작할 예정입니다!