### PR TITLE
AuthTokenAPI에 refreshToken 추가 및 각종 버그 수정

### DIFF
--- a/src/API/customAPI.ts
+++ b/src/API/customAPI.ts
@@ -37,12 +37,14 @@ const axiosApi = ({ options }: any) => {
 };
 
 const axiosAuthTokenApi = ({ options }: any) => {
-  const token = localStorage.getItem('accessToken');
+  const accessToken = localStorage.getItem('accessToken');
+  const refreshToken = localStorage.getItem('refreshToken');
   const instance = axios.create({
     baseURL: APIbaseURL,
     ...options,
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${accessToken}`,
+      RefreshToken: `Bearer ${refreshToken}`,
     },
   });
   instance.interceptors.response.use(

--- a/src/components/LabelBasicSelect/index.tsx
+++ b/src/components/LabelBasicSelect/index.tsx
@@ -6,6 +6,7 @@ interface LabelBasicSelectProps {
   label: string;
   text: string;
   id: string;
+  name: string;
   value: string;
   options: string[];
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -15,13 +16,14 @@ interface LabelBasicSelectProps {
 }
 
 const LabelBasicSelect = (props: LabelBasicSelectProps) => {
-  const { label, text, id, value, options, onChange, onBlur, hasError, errorMessage } = props;
+  const { label, text, id, value, name, options, onChange, onBlur, hasError, errorMessage } = props;
   return (
     <div className={styles.FormContainer}>
       <Label htmlFor={label} text={text} />
       <BasicSelect
         id={id}
         value={value}
+        name={name}
         onChange={onChange}
         options={options}
         onBlur={onBlur}

--- a/src/components/ProfileForm/index.tsx
+++ b/src/components/ProfileForm/index.tsx
@@ -105,6 +105,7 @@ const ProfileForm = () => {
     const getProfile = async () => {
       const response = await API.getProfile({ userId });
       setUserData(response.data);
+      setUserEmail(response.data.email);
     };
     getProfile();
   }, [userId]);
@@ -118,7 +119,6 @@ const ProfileForm = () => {
         id='loginId'
         type='text'
         value={userData.loginId}
-        onChange={onChangeUserData}
       />
       <LabelBasicInput
         label='nickname'

--- a/src/components/ProfileForm/index.tsx
+++ b/src/components/ProfileForm/index.tsx
@@ -67,6 +67,8 @@ const ProfileForm = () => {
   const onSubmitForm = (e: SyntheticEvent) => {
     e.preventDefault();
     updateProfile();
+    // eslint-disable-next-line no-alert
+    alert('수정이 완료되었습니다');
   };
 
   const onChangeUserData = (e: SyntheticEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -145,6 +147,7 @@ const ProfileForm = () => {
       <LabelBasicSelect
         label='mbti'
         text='MBTI'
+        name='mbti'
         id='mbti'
         options={mbtiList}
         value={userData.mbti}
@@ -153,6 +156,7 @@ const ProfileForm = () => {
       <LabelBasicSelect
         label='gender'
         text='성별'
+        name='gender'
         id='gender'
         options={genderList}
         value={userData.gender}

--- a/src/components/SignUpForm/index.tsx
+++ b/src/components/SignUpForm/index.tsx
@@ -334,6 +334,7 @@ const SignUpForm = () => {
         <LabelBasicSelect
           label='mbti'
           text='MBTI'
+          name='mbti'
           id='mbti'
           options={mbtiList}
           value={mbti}
@@ -345,6 +346,7 @@ const SignUpForm = () => {
         <LabelBasicSelect
           label='gender'
           text='성별'
+          name='gender'
           id='gender'
           options={genderList}
           value={gender}

--- a/src/components/styled-components/BasicSelect.tsx
+++ b/src/components/styled-components/BasicSelect.tsx
@@ -3,15 +3,23 @@ import styled from 'styled-components';
 interface SelectProps {
   id: string;
   value: string;
+  name: string;
   options: string[];
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLSelectElement>) => void;
   hasError?: boolean;
 }
 
-const Select = ({ id, value, options, onChange, onBlur, hasError }: SelectProps) => {
+const Select = ({ id, value, name, options, onChange, onBlur, hasError }: SelectProps) => {
   return (
-    <StyledSelect id={id} value={value} onChange={onChange} onBlur={onBlur} hasError={hasError}>
+    <StyledSelect
+      id={id}
+      value={value}
+      name={name}
+      onChange={onChange}
+      onBlur={onBlur}
+      hasError={hasError}
+    >
       {options.map((option) => (
         <option key={option} value={option}>
           {option}


### PR DESCRIPTION
## 개요 :mag:

AuthTokenAPI에 refreshToken 추가 및 각종 버그를 수정하였습니다.

## 작업사항 :memo:

#95 

1. AuthTokenAPI에 refreshToken을 추가하였습니다. 기존에 토큰이 불일치 하여 생긴 Error 500 부분을 수정 하였으며 이를 통해 토큰에 담긴 유저 정보가 get, update 되는것까지 테스트 케이스를 통해 확인하였습니다.
2. LabelBasicSelect에 name속성 태그를 추가하였습니다. name 속성 태그 추가를 통해 기존에 select 부분에 value값이 변경이 되지않던 버그를 수정하였습니다.
3. 기존에 프로필 페이지에서 email의 값이 제대로 전달되지 않던 버그를 수정하였습니다.
4. 프로필수정 완료 시 alert가 발생하도록 설정하였습니다.
